### PR TITLE
fix: GenerateWatermark opts.css error

### DIFF
--- a/dist/gwm.umd.js
+++ b/dist/gwm.umd.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  (global = global || self, global.gwm = factory());
-}(this, (function () { 'use strict';
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.gwm = factory());
+})(this, (function () { 'use strict';
 
   var Watermark = /** @class */ (function () {
       function Watermark(_a) {
@@ -333,5 +333,5 @@
 
   return index;
 
-})));
+}));
 //# sourceMappingURL=gwm.umd.js.map

--- a/src/gwm.ts
+++ b/src/gwm.ts
@@ -33,7 +33,9 @@ export class GenerateWatermark {
   gwmDom?: HTMLElement;
   observer?: GwmObserver | GwmObserverEvent;
 
-  creation(opts: Options) {
+  creation(opts: Options = {
+    txt: `${new Date().toLocaleDateString()} Top secret`,
+  }) {
     this.opts = opts;
     this.opts.css = assignStyle(DEFAULT_STYLE, opts.css);
     this.cancel();

--- a/tslint.json
+++ b/tslint.json
@@ -2,5 +2,8 @@
   "extends": [
     "tslint-config-standard",
     "tslint-config-prettier"
-  ]
+  ],
+  "rules": {
+    "no-unnecessary-type-assertion": false
+  }
 }


### PR DESCRIPTION
`gwm.creation()` does not set default values and causes `opts.css` to report an error.
In addition, can I republish npm? Now the code on npm does not match the files compiled from the source code