### PR TITLE
Add option to specify watermark count

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -119,6 +119,11 @@ gwm.creation()
             <td>body</td>
             <td>传入一个包裹容器，可以是一个`string`类型的选择器，也可以是一个DOM对象，默认为body</td>
         </tr>
+        <tr>
+            <td>count</td>
+            <td>null</td>
+            <td>可选参数，用于直接设置生成水印的数量</td>
+        </tr>
     </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ gwm.creation()
         <tr>
             <td>fontSize</td>
             <td>12</td>
-            <td>水印字体大小</td>
+            <td>Watermark font size</td>
         </tr>
         <tr>
             <td>color</td>
             <td>#000</td>
-            <td>Watermark font size</td>
+            <td>Watermark font color</td>
         </tr>
         <tr>
             <td>alpha</td>
@@ -118,6 +118,11 @@ gwm.creation()
             <td>container</td>
             <td>body</td>
             <td>Pass in a package container, which can be a `string` Type selector, or a DOM object, defaults to body</td>
+        </tr>
+        <tr>
+            <td>count</td>
+            <td>null</td>
+            <td>Optional parameter, used to directly set the number of watermarks generated</td>
         </tr>
     </tbody>
 </table>

--- a/src/core/element.ts
+++ b/src/core/element.ts
@@ -41,12 +41,13 @@ class ElementWay {
     return item;
   }
 
-  public render(): HTMLDivElement {
+  public render(count?: number): HTMLDivElement {
     let i = 0;
     const { width, height } = this.watermark;
     const { clientWidth, clientHeight } = document.documentElement || document.body;
     const column = Math.ceil(clientWidth / width);
     const rows = Math.ceil(clientHeight / height);
+    const total = count || column * rows;
     const wrap = document.createElement('div') as HTMLDivElement;
     bindCSS(wrap, Object.create({
       display: 'flex',
@@ -54,7 +55,7 @@ class ElementWay {
       width: `${ width * column }px`,
       height: `${ height * rows }px`,
     }) as CSSStyleDeclaration, 'normal');
-    for (; i < column * rows; i++) {
+    for (; i < total; i++) {
       wrap.appendChild(this.createItem());
     }
     return wrap;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ interface Options {
   css?: CSSStyleDeclaration;
   destroy?: boolean;
   container?: string | HTMLElement;
+  count?: number; // Optional property to specify the number of watermarks
 }
 
 interface IGwmObserverItemEvent {


### PR DESCRIPTION
Related to #24

Introduces the ability to directly specify the number of watermarks to be generated through a new `count` option.

- Adds a `count?: number` property to the `Options` interface in `src/types/index.ts`, allowing users to specify the desired number of watermarks.
- Modifies the `ElementWay` class in `src/core/element.ts` to accept an optional `count` parameter in the `render` method. This parameter determines the total number of watermarks to generate, overriding the default behavior based on container dimensions.
- Updates documentation in `README-CN.md` and `README.md` to include the new `count` option, providing users with guidance on how to use it to control the number of watermarks generated.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loadchange/gwm/issues/24?shareId=be924e61-d3a2-490c-b90f-ec67afa9c65e).