### PR TITLE
Escape special characters in Canvas mode

### DIFF
--- a/src/core/canvas.ts
+++ b/src/core/canvas.ts
@@ -12,8 +12,13 @@ class CanvasWay {
     this.canvas.setAttribute('height', `${ height }`);
   }
 
+  private escapeSpecialCharacters(txt: string): string {
+    return txt.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
   public render(): string {
-    const { txt, x, y, width, height, font, color, fontSize, alpha, angle } = this.watermark;
+    const { x, y, width, height, font, color, fontSize, alpha, angle } = this.watermark;
+    const txt = this.escapeSpecialCharacters(this.watermark.txt);
     const ctx = this.canvas.getContext('2d');
     if (ctx === null) {
       throw new Error('getContext error');


### PR DESCRIPTION
fixed #23

Implements special character escaping in Canvas mode to prevent XML parse errors in generated watermarks.
- Adds a new method `escapeSpecialCharacters` in `CanvasWay` class to escape special characters (`&`, `<`, `>`) in the watermark text.
- Modifies the `render` method to use `escapeSpecialCharacters` for processing the `txt` property before rendering it on the canvas, ensuring the generated watermark does not cause XML parse errors.