### PR TITLE
Customize default watermark font

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -127,6 +127,14 @@ gwm.creation()
     </tbody>
 </table>
 
+## 自定义字体示例
+要使用自定义字体，您可以在创建水印时通过`font`参数指定所需的字体。例如，要将字体更改为`Arial`，您可以这样做：
+
+```javascript
+gwm.creation({
+  font: 'Arial'
+})
+```
 
 ## 方法
 | 方法            | 说明  |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ gwm.creation()
     </tbody>
 </table>
 
+## Custom Font Example
+To use a custom font, you can specify the desired font through the `font` parameter when creating the watermark. For example, to change the font to `Arial`, you can do it like this:
+
+```javascript
+gwm.creation({
+  font: 'Arial'
+})
+```
 
 ## Method
 | Method            | Explain  |

--- a/src/watermark.ts
+++ b/src/watermark.ts
@@ -14,7 +14,7 @@ class Watermark {
     txt = `${new Date().toLocaleDateString()} Top secret`,
     x = 0,
     y = 50,
-    font = 'microsoft yahe',
+    font = 'Arial', // Updated default font to Arial
     color = '#000',
     fontSize = 12,
     alpha = 0.1,


### PR DESCRIPTION
Related to #21

Updates the default font for watermarks and enhances documentation for custom font usage.

- Changes the default font in the `Watermark` class constructor within `src/watermark.ts` from 'microsoft yahe' to 'Arial', making the watermarks appear less bold by default.
- Adds a new section in `README-CN.md` and `README.md` providing an example on how to customize the font using the `font` parameter, making it easier for users to understand how to change the watermark font to their desired choice.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loadchange/gwm/issues/21?shareId=c8a9e9cf-de7d-4fd9-87d7-befef70b8b46).