### PR TITLE
Check existing positioning before setting properties

### DIFF
--- a/src/helpers/bindCSS.ts
+++ b/src/helpers/bindCSS.ts
@@ -10,6 +10,10 @@ export const assignStyle = (...args: Array<CSSStyleDeclaration | undefined>): CS
 export default (elem: HTMLElement, css: CSSStyleDeclaration, priority?: string | null): HTMLElement => {
   const mergeStyle = assignStyle(elem.style, css);
   for (const key in mergeStyle) {
+    if (key === 'position' && elem.style.position) {
+      // If position property exists, preserve the original value
+      continue;
+    }
     if (priority === 'normal') {
       elem.style[key] = mergeStyle[key];
       continue;


### PR DESCRIPTION
Closed #14

Updates the `bindCSS` function to check for existing `position` property before applying new styles.

- **Preserves existing `position` property**: Checks if the `position` property already exists on an element and, if so, retains the original value instead of overriding it with a new one. This prevents the default fixed position from being applied when a position property is already set, addressing the issue of style disruption when a container already has a positioning context.
- **Applies styles with priority**: Continues to apply other styles with the specified priority, using `elem.style.setProperty` for important styles and direct assignment for normal priority styles.